### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/_posts/2014-10-24-why-proper-docstrings.md
+++ b/_posts/2014-10-24-why-proper-docstrings.md
@@ -49,7 +49,7 @@ def as_chan(create_chan):
 
 And using [sphinx-apidoc](http://sphinx-doc.org/man/sphinx-apidoc.html) and
 [Read the Docs](https://readthedocs.org/) we can generate cool documentation
-[like this](http://microasync.readthedocs.org/en/latest/microasync.html#microasync.async.as_chan).
+[like this](https://microasync.readthedocs.io/en/latest/microasync.html#microasync.async.as_chan).
 And it'll be automatically generated after each push to github.
 
 #### Quick help in IDE

--- a/_posts/2015-02-01-coffeescript-generators.md
+++ b/_posts/2015-02-01-coffeescript-generators.md
@@ -8,7 +8,7 @@ keywords:   coffeescript, generators
 Sometimes it's very hard to understand code with a bunch of callbacks, even if it with promises.
 But in ES6 and in CoffeeScript 1.9 we got generators, so maybe we can avoid
 callbacks with them, and use something like
-[tornado.gen](http://tornado.readthedocs.org/en/latest/gen.html)?
+[tornado.gen](https://tornado.readthedocs.io/en/latest/gen.html)?
 
 And we can, let's look at this little helper function:
 

--- a/_posts/2015-09-09-pytest-docker.md
+++ b/_posts/2015-09-09-pytest-docker.md
@@ -12,7 +12,7 @@ and now it was formalized in a simple py.test plugin &mdash; [pytest-docker-pexp
 It provides few useful fixtures:
 
 * `spawnu` &ndash; `pexpect.spawnu` object attached to a container, it can be used
-to interact with apps inside the container, [read more](https://pexpect.readthedocs.org/en/latest/api/pexpect.html#pexpect.spawn);
+to interact with apps inside the container, [read more](https://pexpect.readthedocs.io/en/latest/api/pexpect.html#pexpect.spawn);
 * `TIMEOUT` &ndash; a special object, that can be used in assertions those checks output;
 * `run_without_docker` &ndash; indicates that tests running without Docker, when
 py.test called with `--run-without-docker`.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
